### PR TITLE
fix:时区转换错误问题 #8

### DIFF
--- a/basic/calendar.go
+++ b/basic/calendar.go
@@ -197,10 +197,14 @@ func JDE2Date(JD float64) time.Time {
 	Days = math.Floor(Days)
 	tz, _ := time.LoadLocation("Local")
 	dates := time.Date(int(Years), time.Month(int(Months)), int(Days), 0, 0, 0, 0, tz)
-	dates = time.Unix(dates.Unix()+int64(tms), int64((tms-math.Floor(tms))*1000000000))
-	return dates
+	return time.Unix(dates.Unix()+int64(tms), int64((tms-math.Floor(tms))*1000000000))
 }
 
+// JDE2DateByZone JDE（儒略日）转日期
+// JD: 儒略日
+// tz: 目标时区
+// byZone: (true: 传入的儒略日视为目标时区当地时间的儒略日，false: 传入的儒略日视为UTC时间的儒略日)
+// 回参：转换后的日期，时区始终为目标时区
 func JDE2DateByZone(JD float64, tz *time.Location, byZone bool) time.Time {
 	JD = JD + 0.5
 	Z := float64(int(JD))
@@ -231,12 +235,12 @@ func JDE2DateByZone(JD float64, tz *time.Location, byZone bool) time.Time {
 	}
 	tms := (Days - math.Floor(Days)) * 24 * 3600
 	Days = math.Floor(Days)
+	var transTz = tz
 	if !byZone {
-		dates := time.Date(int(Years), time.Month(int(Months)), int(Days), 0, 0, 0, 0, time.UTC)
-		return time.Unix(dates.Unix()+int64(tms), int64((tms-math.Floor(tms))*1000000000)).In(tz)
+		transTz = time.UTC
 	}
-	dates := time.Date(int(Years), time.Month(int(Months)), int(Days), 0, 0, 0, 0, tz)
-	return time.Unix(dates.Unix()+int64(tms), int64((tms-math.Floor(tms))*1000000000))
+	return time.Date(int(Years), time.Month(int(Months)), int(Days), 0, 0, 0, 0, transTz).
+		Add(time.Duration(int64(1000000000 * tms))).In(tz)
 }
 
 func GetLunar(year, month, day int, tz float64) (lmonth, lday int, leap bool, result string) {

--- a/basic/calendar_test.go
+++ b/basic/calendar_test.go
@@ -5,12 +5,8 @@ import (
 	"fmt"
 	"math"
 	"os"
-	"testing"
 )
 
-func TestGenerateMagic(t *testing.T) {
-	generateMagicNumber()
-}
 func generateMagicNumber() {
 	//0月份 00000 日期 0000闰月 0000000000000 农历信息
 	var tz = 8.0000 / 24.000
@@ -18,7 +14,6 @@ func generateMagicNumber() {
 	spYear := make(map[int][]int)
 	var upper []uint16
 	var lower []uint16
-	var full []uint32
 	//var info uint32 = 0
 	for year := 1899; year <= 2401; year++ {
 		fmt.Println(year)
@@ -94,16 +89,13 @@ func generateMagicNumber() {
 	}
 	for year := 1900; year <= 2400; year++ {
 		fmt.Println(year)
-		magic := magicNumber(yearMap[year], spYear[year])
-		up, low := magicNumberSpilt(magic)
+		up, low := magicNumberSpilt(magicNumber(yearMap[year], spYear[year]))
 		upper = append(upper, up)
 		lower = append(lower, uint16(low))
-		full = append(full, uint32(magic))
 	}
 	res := make(map[string]interface{})
 	res["up"] = upper
 	res["low"] = lower
-	res["full"] = full
 	d, _ := json.Marshal(res)
 	os.WriteFile("test.json", d, 0644)
 }

--- a/basic/sun_test.go
+++ b/basic/sun_test.go
@@ -4,7 +4,6 @@ import (
 	"github.com/starainrt/astro/tools"
 	"fmt"
 	"math"
-	"os"
 	"testing"
 	"time"
 )
@@ -163,20 +162,17 @@ func TestJQDate(t *testing.T) {
 		return math.Floor(d) + 0.5
 	}
 	c := 0
-	var info string
 	for year := 1900; year <= 2600; year++ {
 		for pos := 0; pos < 360; pos += 15 {
-			n := newGetJQTime(year, pos) + 8.0/24.000000
-			o := GetJQTime(year, pos) + 8.0/24.0000000
+			n := newGetJQTime(year, pos)
+			o := GetJQTime(year, pos)
 			if trimDay(n) != trimDay(o) {
 				c++
-				fmt.Printf("\"%d%03d\"=>%v  %v\n", year, pos, JDE2Date(trimDay(o)), JDE2Date(trimDay(n)))
-				info += fmt.Sprintf("\"%d%03d\"=>%.0f,", year, pos, trimDay(o)-trimDay(n))
+				fmt.Printf("\"%d%03d\":%.0f,", year, pos, trimDay(o)-trimDay(n))
 			}
 		}
 	}
 	fmt.Println(c)
-	os.WriteFile("test.txt", []byte(info), 0644)
 }
 
 func newGetJQTime(Year, Angle int) float64 { //节气时间

--- a/calendar/chinese.go
+++ b/calendar/chinese.go
@@ -143,6 +143,9 @@ recalc:
 	magic := int32(upper[idx])<<8 + int32(lower[idx])
 	springMonth := (magic&0x800000)>>23 + 1
 	springDay := (magic & 0x7FFFFF) >> 18
+	if springMonth == int32(month) && springDay == int32(day) {
+		return 1, 1, false, "正月初一"
+	}
 	if !useGoto && (springMonth > int32(month) || (springMonth == int32(month) && springDay > int32(day))) {
 		year--
 		useGoto = true

--- a/mercury/mercury_test.go
+++ b/mercury/mercury_test.go
@@ -7,8 +7,20 @@ import (
 )
 
 func TestMercury(t *testing.T) {
-	date := time.Now().Add(time.Hour * -24)
-	fmt.Println(CulminationTime(date, 115))
-	fmt.Println(RiseTime(date, 115, 23, 0, false))
-	fmt.Println(DownTime(date, 115, 23, 0, false))
+	tz := time.FixedZone("CST", 8*3600)
+	date := time.Date(2022, 01, 20, 00, 00, 00, 00, tz)
+	if NextConjunction(date).Unix() != 1642933683 {
+		t.Fatal(NextConjunction(date).Unix())
+	}
+	if CulminationTime(date, 115).Unix() != 1642654651 {
+		t.Fatal(CulminationTime(date, 115).Unix())
+	}
+	date, err := (RiseTime(date, 115, 40, 0, false))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if date.Unix() != 1642636481 {
+		t.Fatal(date.Unix())
+	}
+	fmt.Println(DownTime(date, 115, 40, 0, false))
 }

--- a/moon/moon.go
+++ b/moon/moon.go
@@ -209,11 +209,14 @@ func Phase(date time.Time) float64 {
 }
 
 // ShuoYue 朔月
+// 返回Date对应UTC世界时的月相大小
 func ShuoYue(year float64) time.Time {
 	jde := basic.TD2UT(basic.CalcMoonSH(year, 0), false)
 	return basic.JDE2DateByZone(jde, time.UTC, false)
 }
 
+// NextShuoYue 下次朔月时间
+// 返回date之后的下一个朔月时间（UTC时间）
 func NextShuoYue(date time.Time) time.Time {
 	return nextMoonPhase(date, 0)
 }

--- a/moon/moon_test.go
+++ b/moon/moon_test.go
@@ -13,49 +13,42 @@ func Test_MoonPhaseDate(t *testing.T) {
 	//指定日期后的下一个朔月
 	moonPhase01 := NextShuoYue(date)
 	fmt.Println("下一朔月", moonPhase01)
-	if moonPhase01.Unix() != 1643694349 {
-		t.Fatal(moonPhase01)
+	if moonPhase01.Unix() != 1643694356 {
+		t.Fatal(moonPhase01.Unix())
 	}
 	//指定日期后的上一个朔月
 	moonPhase01 = LastShuoYue(date)
 	fmt.Println("上一朔月", moonPhase01)
-	if moonPhase01.Unix() != 1641148399 {
-		t.Fatal(moonPhase01)
+	if moonPhase01.Unix() != 1641148406 {
+		t.Fatal(moonPhase01.Unix())
 	}
 	//离指定日期最近的朔月
 	moonPhase01 = ClosestShuoYue(date)
 	fmt.Println("最近朔月", moonPhase01)
-	if moonPhase01.Unix() != 1643694349 {
-		t.Fatal(moonPhase01)
+	if moonPhase01.Unix() != 1643694356 {
+		t.Fatal(moonPhase01.Unix())
 	}
 	//离指定日期最近的望月时间
 	moonPhase01 = ClosestWangYue(date)
 	fmt.Println("最近望月", moonPhase01)
-	if moonPhase01.Unix() != 1642463294 {
-		t.Fatal(moonPhase01)
+	if moonPhase01.Unix() != 1642463301 {
+		t.Fatal(moonPhase01.Unix())
 	}
 	//离指定日期最近的上弦月时间
 	moonPhase01 = ClosestShangXianYue(date)
 	fmt.Println("最近上弦月", moonPhase01)
-	if moonPhase01.Unix() != 1641751864 {
-		t.Fatal(moonPhase01)
+	if moonPhase01.Unix() != 1641751871 {
+		t.Fatal(moonPhase01.Unix())
 	}
 	//离指定日期最近的下弦月时间
 	moonPhase01 = ClosestXiaXianYue(date)
 	fmt.Println("最近下弦月", moonPhase01)
-	if moonPhase01.Unix() != 1643118043 {
-		t.Fatal(moonPhase01)
+	if moonPhase01.Unix() != 1643118050 {
+		t.Fatal(moonPhase01.Unix())
 	}
 	//-------------------
 	for i := 0; i < 26; i++ {
 		moonPhase01 = LastShuoYue(moonPhase01)
 		fmt.Println("上一朔月", moonPhase01)
 	}
-}
-
-func TestMoon(t *testing.T) {
-	now := time.Now()
-	fmt.Println(RiseTime(now, 115, 40, 0, true))
-	fmt.Println(CulminationTime(now, 115, 40))
-	fmt.Println(DownTime(now, 115, 40, 0, true))
 }

--- a/neptune/neptune_test.go
+++ b/neptune/neptune_test.go
@@ -7,8 +7,20 @@ import (
 )
 
 func TestNeptune(t *testing.T) {
-	date := time.Now().Add(time.Hour * -24)
-	fmt.Println(CulminationTime(date, 115))
-	fmt.Println(RiseTime(date, 115, 23, 0, false))
-	fmt.Println(DownTime(date, 115, 23, 0, false))
+	tz := time.FixedZone("CST", 8*3600)
+	date := time.Date(2022, 01, 20, 00, 00, 00, 00, tz)
+	if NextConjunction(date).Unix() != 1647171796 {
+		t.Fatal(NextConjunction(date).Unix())
+	}
+	if CulminationTime(date, 115).Unix() != 1642665021 {
+		t.Fatal(CulminationTime(date, 115).Unix())
+	}
+	date, err := (RiseTime(date, 115, 40, 0, false))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if date.Unix() != 1642644398 {
+		t.Fatal(date.Unix())
+	}
+	fmt.Println(DownTime(date, 115, 40, 0, false))
 }

--- a/sun/sun_test.go
+++ b/sun/sun_test.go
@@ -7,8 +7,23 @@ import (
 )
 
 func TestSun(t *testing.T) {
-	now := time.Now()
-	fmt.Println(RiseTime(now, 115, 40, 0, true))
+	ja, err := time.LoadLocation("Asia/Tokyo")
+	if err != nil {
+		t.Fatal(err)
+	}
+	now, err := time.ParseInLocation("2006-01-02 15:04:05", "2020-01-01 00:00:00", ja)
+	if err != nil {
+		t.Fatal(err)
+	}
+	d, err := RiseTime(now, 115, 40, 0, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if d.Format("2006-01-02 15:04:05") != "2020-01-01 08:41:45" {
+		t.Fatal(d.Format("2006-01-02 15:04:05"))
+	}
 	fmt.Println(CulminationTime(now, 115))
 	fmt.Println(DownTime(now, 115, 40, 0, true))
+	fmt.Println(MorningTwilight(now, 115, 40, -6))
+	fmt.Println(EveningTwilight(now, 115, 40, -6))
 }


### PR DESCRIPTION
修复时区转换错误问题 #8

## bug描述
1. sun.RiseTime等函数使用了basic.JDE2DateByZone()进行时区转换。调用sun.RiseTime等函数时，如果传入的时间时区与time.Local时区不一致，因为时区转换有误，结果与实际不符。
2. sun.MorningTwilight等函数错误使用basic.JDE2Date()进行时区转换。如果传入的时间时区与time.Local时区不一致，因为没有进行时区转换，结果与实际不符。

## 原因
basic.JDE2DateByZone()函数负责将JDE儒略日转换为带时区的time.Time对象，入参有三个：
```
jd: 儒略日
tz: 目标时区
byZone: (true: 传入的儒略日视为目标时区当地时间的儒略日，false: 传入的儒略日视为UTC时间的儒略日)
```
此函数最后会通过time.Unix()返回一个time.Time对象，返回时间对象的时区是time.Local，而编写函数时误以为返回的时区是time.UTC

## 修正  Closes #8 
1. 使用time.Time对象的Add()方法替换time.Unix()
2. sun.MorningTwilight等函数使用basic.JDE2DateByZone()进行时区转换