### PR TITLE
bug fix:快速模式下，部分年份腊月十二显示为正月初一的问题

### DIFF
--- a/calendar/chinese.go
+++ b/calendar/chinese.go
@@ -143,7 +143,7 @@ recalc:
 	magic := int32(upper[idx])<<8 + int32(lower[idx])
 	springMonth := (magic&0x800000)>>23 + 1
 	springDay := (magic & 0x7FFFFF) >> 18
-	if springMonth == int32(month) && springDay == int32(day) {
+	if !useGoto && springMonth == int32(month) && springDay == int32(day) {
 		return 1, 1, false, "正月初一"
 	}
 	if !useGoto && (springMonth > int32(month) || (springMonth == int32(month) && springDay > int32(day))) {

--- a/calendar/chinese_test.go
+++ b/calendar/chinese_test.go
@@ -18,6 +18,7 @@ type lunarSolar struct {
 
 func Test_ChineseCalendar(t *testing.T) {
 	var testData = []lunarSolar{
+		{Lyear: 1995, Lmonth: 12, Lday: 12, Leap: false, Year: 1996, Month: 1, Day: 31},
 		{Lyear: 2034, Lmonth: 1, Lday: 1, Leap: false, Year: 2034, Month: 2, Day: 19},
 		{Lyear: 2033, Lmonth: 12, Lday: 30, Leap: false, Year: 2034, Month: 2, Day: 18},
 		{Lyear: 2033, Lmonth: 11, Lday: 27, Leap: true, Year: 2034, Month: 1, Day: 17},
@@ -37,19 +38,37 @@ func Test_ChineseCalendar(t *testing.T) {
 		{Lyear: 2021, Lmonth: 12, Lday: 29, Leap: false, Year: 2022, Month: 1, Day: 31},
 	}
 	for _, v := range testData {
-		var lyear int = v.Year
-		lmonth, lday, leap, desp := SolarToLunar(time.Date(v.Year, time.Month(v.Month), v.Day, 0, 0, 0, 0, time.Local))
-		if lmonth > v.Month {
-			lyear--
-		}
-		fmt.Println(lyear, desp, v.Year, v.Month, v.Day)
-		if lyear != v.Lyear || lmonth != v.Lmonth || lday != v.Lday || leap != v.Leap {
-			t.Fatal(v, lyear, lmonth, lday, leap, desp)
-		}
+		{
+			var lyear int = v.Year
+			lmonth, lday, leap, desp := SolarToLunar(time.Date(v.Year, time.Month(v.Month), v.Day, 0, 0, 0, 0, time.Local))
+			if lmonth > v.Month {
+				lyear--
+			}
+			fmt.Println(lyear, desp, v.Year, v.Month, v.Day)
+			if lyear != v.Lyear || lmonth != v.Lmonth || lday != v.Lday || leap != v.Leap {
+				t.Fatal(v, lyear, lmonth, lday, leap, desp)
+			}
 
-		date := LunarToSolar(v.Lyear, v.Lmonth, v.Lday, v.Leap)
-		if date.Year() != v.Year || int(date.Month()) != v.Month || date.Day() != v.Day {
-			t.Fatal(v, date)
+			date := LunarToSolar(v.Lyear, v.Lmonth, v.Lday, v.Leap)
+			if date.Year() != v.Year || int(date.Month()) != v.Month || date.Day() != v.Day {
+				t.Fatal(v, date)
+			}
+		}
+		{
+			var lyear int = v.Year
+			lmonth, lday, leap, desp := RapidSolarToLunar(time.Date(v.Year, time.Month(v.Month), v.Day, 0, 0, 0, 0, time.Local))
+			if lmonth > v.Month {
+				lyear--
+			}
+			fmt.Println(lyear, desp, v.Year, v.Month, v.Day)
+			if lyear != v.Lyear || lmonth != v.Lmonth || lday != v.Lday || leap != v.Leap {
+				t.Fatal(v, lyear, lmonth, lday, leap, desp)
+			}
+
+			date := RapidLunarToSolar(v.Lyear, v.Lmonth, v.Lday, v.Leap)
+			if date.Year() != v.Year || int(date.Month()) != v.Month || date.Day() != v.Day {
+				t.Fatal(v, date)
+			}
 		}
 	}
 }


### PR DESCRIPTION
## 问题背景
快速模式下，magic会记录每年正月初一对应的农历年份，所以代码中直接通过判断传入年份日期的月(month)和日(day)与magic记录的一致性来简单判定是否为正月初一。
但对于公历月份为1或2月，实际农历月份为腊月的日期，其农历在历法上还未到新年，但在公历上已跨年，而magic又是按公历获取的，故此时获取到的magic不正确，程序会重新获取公历年份-1的magic，并重走流程。
此时，如果公历年份-1的magic中记录的春节月份日期与传入变量的日期一致，则会直接错误判断为正月初一，实际上公历上相差了一年。
此情况只会发生在后一年春节比今年晚的年份，在这种场景下，跨年会存在闰月，所以，这个错误的日期一般与下年春节日期相差30-(365.2422-29.5306*12)~=19天，也就是腊月十一~十二这两天。

## 修正方式
重新获取公历年份-1的magic后，不进行正月初一的快速判断流程。
